### PR TITLE
Deadline fix

### DIFF
--- a/connection_manager.go
+++ b/connection_manager.go
@@ -137,7 +137,6 @@ func NewConnection(conn net.Conn, id string) *Connection {
 func (c *Connection) Read(readTo chan CnxMgrMsg, done chan string, timeout time.Duration) {
 	scanner := bufio.NewScanner(c.conn)
 	scanner.Split(ScanNullTerm)
-	c.conn.SetReadDeadline(time.Now().Add(timeout))
 	for {
 		if ok := scanner.Scan(); !ok {
 			break
@@ -147,6 +146,8 @@ func (c *Connection) Read(readTo chan CnxMgrMsg, done chan string, timeout time.
 			ID:   c.id,
 			Msg:  (scanner.Text() + "\000"), // have to append the null byte that the scanner strips
 		}
+		log.Printf("Setting Read Deadline for conn %s\n", c.id)
+		c.conn.SetReadDeadline(time.Now().Add(timeout))
 	}
 	done <- c.id
 }

--- a/connection_manager.go
+++ b/connection_manager.go
@@ -189,7 +189,7 @@ func ScanNullTerm(data []byte, atEOF bool) (int, []byte, error) {
 
 	// if we did not find a null-terminated frame, still need to check for \n
 	if len(data) > 0 && data[0] == '\n' {
-		return 1, []byte{data[0],}, nil
+		return 1, []byte{data[0]}, nil
 	}
 
 	// if we are at EOF and we have data, return it so we can see what's going on

--- a/connection_manager.go
+++ b/connection_manager.go
@@ -149,11 +149,7 @@ func (c *Connection) Read(readTo chan CnxMgrMsg, done chan string, timeout time.
 				ID:   c.id,
 				Msg:  (txt + "\000"), // have to append the null byte that the scanner strips
 			}
-		} else {
-			// TODO: find a way to write a test for this
-			log.Printf("Received heartbeat from conn %s\n", c.id)
 		}
-		log.Printf("Setting Read Deadline for conn %s\n", c.id)
 		c.conn.SetReadDeadline(time.Now().Add(timeout).Add(500 * time.Millisecond))
 	}
 	done <- c.id

--- a/connection_manager.go
+++ b/connection_manager.go
@@ -141,13 +141,19 @@ func (c *Connection) Read(readTo chan CnxMgrMsg, done chan string, timeout time.
 		if ok := scanner.Scan(); !ok {
 			break
 		}
-		readTo <- CnxMgrMsg{
-			Type: FRAME,
-			ID:   c.id,
-			Msg:  (scanner.Text() + "\000"), // have to append the null byte that the scanner strips
+		txt := scanner.Text()
+		if txt != "\n" {
+			// if it's not just a heartbeat EOL, send the frame
+			readTo <- CnxMgrMsg{
+				Type: FRAME,
+				ID:   c.id,
+				Msg:  (txt + "\000"), // have to append the null byte that the scanner strips
+			}
+		} else {
+			log.Printf("Received heartbeat from conn %s\n", c.id)
 		}
 		log.Printf("Setting Read Deadline for conn %s\n", c.id)
-		c.conn.SetReadDeadline(time.Now().Add(timeout))
+		c.conn.SetReadDeadline(time.Now().Add(timeout).Add(500 * time.Millisecond))
 	}
 	done <- c.id
 }
@@ -182,6 +188,11 @@ func ScanNullTerm(data []byte, atEOF bool) (int, []byte, error) {
 	if i := bytes.IndexByte(data, '\000'); i >= 0 {
 		// there is a null-terminated frame
 		return i + 1, data[0:i], nil
+	}
+
+	// if we did not find a null-terminated frame, still need to check for \n
+	if len(data) > 0 && data[0] == '\n' {
+		return 1, []byte{data[0],}, nil
 	}
 
 	// if we are at EOF and we have data, return it so we can see what's going on

--- a/connection_manager.go
+++ b/connection_manager.go
@@ -150,6 +150,7 @@ func (c *Connection) Read(readTo chan CnxMgrMsg, done chan string, timeout time.
 				Msg:  (txt + "\000"), // have to append the null byte that the scanner strips
 			}
 		} else {
+			// TODO: find a way to write a test for this
 			log.Printf("Received heartbeat from conn %s\n", c.id)
 		}
 		log.Printf("Setting Read Deadline for conn %s\n", c.id)

--- a/connection_manager_test.go
+++ b/connection_manager_test.go
@@ -80,7 +80,7 @@ func TestScanNullTerm(t *testing.T) {
 	empty := []byte("")
 	nullTerm := []byte("Null-term\000")
 	multipleNull := []byte("Null-term\000another\000")
-	noNull := []byte("Justwords")
+	noNull := []byte("Justwords\n")
 	var tests = []struct {
 		input []byte
 		eof   bool
@@ -92,7 +92,7 @@ func TestScanNullTerm(t *testing.T) {
 		{nullTerm, false, 10, nullTerm[:len(nullTerm)-1], nil},
 		{multipleNull, false, 10, nullTerm[:len(nullTerm)-1], nil},
 		{noNull, false, 0, nil, nil},
-		{noNull, true, 9, noNull, nil},
+		{noNull, true, 10, noNull, nil},
 	}
 
 	for _, tt := range tests {

--- a/engine.go
+++ b/engine.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"strconv"
 )
 
 type Engine struct {
@@ -143,9 +144,10 @@ func (e *Engine) Start() error {
 func (e *Engine) handleConnect(msg CnxMgrMsg) string {
 	// e.handleConnect takes a CONNECT or STOMP frame and produces a CONNECTED frame
 	// TODO: handle protocol negotiation ERROR generation
+	heartbeatStr := strconv.Itoa(int(e.CM.timeout.Milliseconds()))
 	return UnmarshalFrame(Frame{
 		Command: CONNECTED,
-		Headers: map[string]string{"accept-version": "1.2", "host": e.CM.Hostname()},
+		Headers: map[string]string{"accept-version": "1.2", "host": e.CM.Hostname(), "heart-beat": "0," + heartbeatStr},
 		Body:    "",
 	})
 }

--- a/engine.go
+++ b/engine.go
@@ -144,10 +144,13 @@ func (e *Engine) Start() error {
 func (e *Engine) handleConnect(msg CnxMgrMsg) string {
 	// e.handleConnect takes a CONNECT or STOMP frame and produces a CONNECTED frame
 	// TODO: handle protocol negotiation ERROR generation
-	heartbeatStr := strconv.Itoa(int(e.CM.timeout.Milliseconds()))
+	heartbeatStr := "0"
+	if e.CM.timeout.Milliseconds() > 0 {
+		heartbeatStr := strconv.Itoa(int(e.CM.timeout.Milliseconds()))
+	} 
 	return UnmarshalFrame(Frame{
 		Command: CONNECTED,
-		Headers: map[string]string{"accept-version": "1.2", "host": e.CM.Hostname(), "heart-beat": "0," + heartbeatStr},
+		Headers: map[string]string{"version": "1.2", "host": e.CM.Hostname(), "heart-beat": "0," + heartbeatStr},
 		Body:    "",
 	})
 }

--- a/engine.go
+++ b/engine.go
@@ -147,7 +147,7 @@ func (e *Engine) handleConnect(msg CnxMgrMsg) string {
 	heartbeatStr := "0"
 	if e.CM.timeout.Milliseconds() > 0 {
 		heartbeatStr = strconv.Itoa(int(e.CM.timeout.Milliseconds()))
-	} 
+	}
 	return UnmarshalFrame(Frame{
 		Command: CONNECTED,
 		Headers: map[string]string{"version": "1.2", "host": e.CM.Hostname(), "heart-beat": "0," + heartbeatStr},

--- a/engine.go
+++ b/engine.go
@@ -146,7 +146,7 @@ func (e *Engine) handleConnect(msg CnxMgrMsg) string {
 	// TODO: handle protocol negotiation ERROR generation
 	heartbeatStr := "0"
 	if e.CM.timeout.Milliseconds() > 0 {
-		heartbeatStr := strconv.Itoa(int(e.CM.timeout.Milliseconds()))
+		heartbeatStr = strconv.Itoa(int(e.CM.timeout.Milliseconds()))
 	} 
 	return UnmarshalFrame(Frame{
 		Command: CONNECTED,


### PR DESCRIPTION
Previously the Read deadline was set once, so any connection was closed in X seconds.

This PR does these things:

1) Notifies any clients of the heartbeat requirements set using the TCPDeadline config value.
2) Modifies the SplitFunc ScanNullByte to interpret a single \n outside of a message as a heartbeat and renew the deadline.