### PR TITLE
Experimental default.nix to allow nix build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ To overwrite Stomper's default settings, you can pass environment variables to t
 $ docker run -d -p 32801:32801 --env STOMPER_TOPICS="/queue/env1 /queue/env2" ghcr.io/tydar/stomper:main
 ```
 
+## Nix build support
+
+This project contains a minimal `default.nix`. To build the Stomper using Nix, you should follow these steps:
+
+1) On NixOS, ensure you are working with Go installed: `nix-shell -p go`.
+2) Run `go mod vendor` in the project directory.
+3) Run `nix build`.
+
 ## Configuration options
 
 | Parameter | ENV variable | Default Value | Description |

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,16 @@
+with import <nixpkgs> {};
+
+buildGoModule {
+        pname = "stomper";
+        version = "0.0.1";
+
+        src = ./.;
+
+        # requires running go mod vendor prior to build
+        # on NixOS, do this:
+        # $ nix-shell -p go
+        # $ go mod vendor
+        # $ nix build
+
+        vendorSha256 = null;
+}


### PR DESCRIPTION
This default.nix file requires these steps:

   1) run `go mod vendor` in the source directory
   2) run `nix build`